### PR TITLE
Change CSS class names, add border to input

### DIFF
--- a/x-pack/legacy/plugins/canvas/public/components/expression/expression.scss
+++ b/x-pack/legacy/plugins/canvas/public/components/expression/expression.scss
@@ -8,11 +8,11 @@
   top: $euiSizeL;
 }
 
-.expressionInput--editor {
+.canvasExpressionInput--editor {
   height: 250px;
   flex-grow: 1;
   flex-basis: auto;
-
+  border: $euiBorderThin;
   display: flex;
   flex-direction: row;
 
@@ -27,13 +27,13 @@
   display: flex;
   flex-direction: column;
 
-  .expressionInput {
+  .canvasExpressionInput {
     flex-grow: 1;
     display: flex;
     flex-direction: column;
   }
 
-  .expressionInput--inner {
+  .canvasExpressionInput--inner {
     flex-grow: 1;
   }
 

--- a/x-pack/legacy/plugins/canvas/public/components/expression_input/expression_input.tsx
+++ b/x-pack/legacy/plugins/canvas/public/components/expression_input/expression_input.tsx
@@ -212,15 +212,15 @@ export class ExpressionInput extends React.Component<Props> {
       ? null
       : 'This is the coded expression that backs this element. You better know what you are doing here.';
     return (
-      <div className="expressionInput">
+      <div className="canvasExpressionInput">
         <EuiFormRow
-          className="expressionInput--inner"
+          className="canvasExpressionInput--inner"
           fullWidth
           isInvalid={Boolean(error)}
           error={error}
           helpText={helpText}
         >
-          <div className="expressionInput--editor">
+          <div className="canvasExpressionInput--editor">
             <Editor
               languageId="expression"
               languageDef={language}


### PR DESCRIPTION
- adds border to expression input so that it doesn't blend into the container
- use app name as prefix for custom CSS classes (standard practice throughout Kibana)